### PR TITLE
Add multistage build file and update jdk to newer release

### DIFF
--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -1,0 +1,52 @@
+# A JDK 9 with Alpine Linux
+FROM alpine:3.6 as builder
+# Add the musl-based JDK 9 distribution
+RUN mkdir /opt
+# Download from http://jdk.java.net/9/
+
+ARG OPENJDK9_ALPINE_URL=http://download.java.net/java/jdk9-alpine/archive/181/binaries/jdk-9-ea+181_linux-x64-musl_bin.tar.gz
+# Download and untar openjdk9-alpine from $OPENJDK9_ALPINE_URL
+RUN mkdir -p /usr/lib/jvm \
+  && wget -c -O- --header "Cookie: oraclelicense=accept-securebackup-cookie" $OPENJDK9_ALPINE_URL \
+    | tar -zxC /usr/lib/jvm
+
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
+# Set up env variables
+ENV JAVA_HOME /usr/lib/jvm/jdk-9
+ENV PATH=$PATH:$JAVA_HOME/bin
+
+WORKDIR /app
+RUN mkdir -p /app/src
+COPY ./src /app/src
+
+RUN mkdir -p build/classes/main
+RUN javac -d build/classes/main \
+    src/main/java/module-info.java \
+    src/main/java/fi/linuxbox/http/Main.java
+
+RUN mkdir -p build/jmods
+RUN jar --create --file build/jmods/http-server-1.0-SNAPSHOT.jar \
+    --main-class fi.linuxbox.http.Main \
+    -C build/classes/main .
+ENV TARGET_JMODS=$JAVA_HOME/jmods
+
+# RUN ls -la $JAVA_HOME/bin
+RUN jlink --module-path build/jmods:$TARGET_JMODS \
+          --strip-debug --vm server --compress 2 \
+          --class-for-name --no-header-files --no-man-pages \
+          --dedup-legal-notices=error-if-not-same-content \
+          --add-modules http.server \
+          --output build/jre/native
+# RUN du -csh build/jre/native
+
+# Builder Stage is all done
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /app/build/jre/native/bin
+
+COPY --from=builder /app/build/jre/native /app/build/jre/native
+
+CMD ["/app/build/jre/native/bin/java", "-m", "http.server"]


### PR DESCRIPTION
+ Adds multistage dockerfile
+ Updates jdk version to newer release

Rather than build with a Makefile, I preferred to use a docker multi-stage build to yield the same result, but without the makefile. 

Multi-stage builds are a new feature requiring Docker 17.05 or higher on the daemon and client. Multistage builds are useful to anyone who has struggled to optimize Dockerfiles while keeping them easy to read and maintain.

With multi-stage builds, you use multiple FROM statements in your Dockerfile. Each FROM instruction can use a different base, and each of them begins a new stage of the build. You can selectively copy artifacts from one stage to another, leaving behind everything you don’t want in the final image.

